### PR TITLE
feat: Implement the get_stats console command

### DIFF
--- a/main/console.c
+++ b/main/console.c
@@ -22,6 +22,7 @@
 #include "commands.h"
 #include "bma400_driver.h"
 #include "esp_log.h"
+#include "freertos/task.h"
 
 static const char *TAG = "CONSOLE";
 
@@ -1031,7 +1032,16 @@ int cmd_set_max_accel(int argc, char **argv) {
 }
 
 int cmd_get_stats(int argc, char **argv) {
-    printf("Task stats not implemented.\n");
+    char *buffer = malloc(2048);
+    if (buffer == NULL) {
+        printf("Error: Failed to allocate buffer for task list.\n");
+        return 1;
+    }
+    printf("Task Name\tStatus\tPrio\tHWM\tTask#\n");
+    printf("------------------------------------------------\n");
+    vTaskList(buffer);
+    printf("%s\n", buffer);
+    free(buffer);
     return 0;
 }
 


### PR DESCRIPTION
The `get_stats` console command was previously unimplemented. This change provides a full implementation using the FreeRTOS `vTaskList()` function.

The command now prints a formatted table of all running tasks and their runtime statistics, which is useful for debugging and system monitoring. The implementation allocates a buffer for the task list, calls `vTaskList()`, prints the formatted list to the console, and then frees the buffer.