### PR TITLE
fix: Prevent freeze in set_pos command

### DIFF
--- a/main/console.c
+++ b/main/console.c
@@ -776,7 +776,10 @@ int cmd_set_pos(int argc, char **argv) {
     request.reg_address = REG_GOAL_POSITION;
     request.value = (uint16_t)pos;
     request.response_queue = NULL;
-    xQueueSend(g_bus_request_queues[arm_id], &request, portMAX_DELAY);
+    if (xQueueSend(g_bus_request_queues[arm_id], &request, pdMS_TO_TICKS(100)) != pdPASS) {
+        printf("Error: Failed to send request to bus manager. Queue might be full.\n");
+        return 1;
+    }
     return 0;
 }
 


### PR DESCRIPTION
The `set_pos` console command was using `portMAX_DELAY` when sending a request to the bus manager queue. This could cause the console task to block indefinitely if the queue was full, leading to a device freeze.

This commit changes the block time to a 100ms timeout (`pdMS_TO_TICKS(100)`) and adds a check on the return value of `xQueueSend`. If the queue is full and the request cannot be sent within the timeout, an error message is printed to the console, and the command returns, preventing the freeze.