### PR TITLE
fix: Remove duplicate call to initialize_console

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -999,7 +999,6 @@ void app_main(void) {
     initialize_usb_cdc(); // For Feetech slave command interface
     mcp_server_init();
     
-    initialize_console();
     planner_init();
     behavior_init();
 


### PR DESCRIPTION
The `initialize_console()` function was being called from both `app_main` and the `console_task`. This resulted in an attempt to install the UART driver twice for the same port, causing an `ESP_FAIL` error and a device reboot.

This commit removes the incorrect call from `app_main`, ensuring that the console is initialized only once by its own dedicated task.