### PR TITLE
test: Update Feetech test position to calibrated neutral

### DIFF
--- a/tests/unit_test_script.py
+++ b/tests/unit_test_script.py
@@ -303,7 +303,7 @@ def run_feetech_tests(port, use_mock=False):
         print(f"  [FEETECH] Test 2 (read_word): PASSED (Read back {read_val})")
 
         # Test 3: REG_WRITE and ACTION
-        test_pos_3 = 3000
+        test_pos_3 = 2045
         client.reg_write_word(servo_id, 42, test_pos_3) # No response expected for REG_WRITE
         time.sleep(0.1)
         client.action() # No response for broadcast ACTION


### PR DESCRIPTION
The `REG_WRITE`/`ACTION` test in the Feetech integration test suite is updated to use a target position of 2045. This value is the calibrated neutral position for the servo, which makes the test more precise and less likely to fail due to safety limits.