### PR TITLE
test: Add mock response for set_accel command

### DIFF
--- a/tests/robot_client.py
+++ b/tests/robot_client.py
@@ -188,6 +188,8 @@ class MockSerial:
             self._in_buffer += b"Forcing network re-initialization\nrobot>"
         elif b"start-data-acq" in data:
             self._in_buffer += b"Starting data acquisition\nrobot>"
+        elif b"set_accel 100" in data:
+            self._in_buffer += b"Servo acceleration set to 100 for all servos.\nrobot>"
         elif b"get_accel_raw" in data:
             self._in_buffer += b"Raw Accelerometer: X=0.0, Y=0.0, Z=1.0 (G)\nrobot>"
         elif b"start_map_cal 1" in data:


### PR DESCRIPTION
The console unit tests were failing because the pre-test step to set a safe acceleration did not have a corresponding mock response in the `MockSerial` class. This caused the test to time out and fail the assertion.

This commit adds the necessary mock response to `robot_client.py` to simulate the output of the `set_accel` command, allowing the unit tests to pass.