### PR TITLE
test: Add mock responses for invalid set_pos arguments

### DIFF
--- a/tests/robot_client.py
+++ b/tests/robot_client.py
@@ -160,6 +160,10 @@ class MockSerial:
             self._in_buffer += b"State learning loop set to off\nrobot>"
         elif b"set-mode 2" in data:
             self._in_buffer += b"Operating mode set to: 2\nrobot>"
+        elif b"set_pos 99 2048" in data:
+            self._in_buffer += b"Error: Servo ID must be between 1 and 6\nrobot>"
+        elif b"set_pos 1 9999" in data:
+            self._in_buffer += b"Error: Position must be between 0 and 4095\nrobot>"
         elif b"set_pos 1 2048" in data:
             self._in_buffer += b"Set servo 1 on arm 0 to position 2048\nrobot>"
         elif b"get_current 1" in data:


### PR DESCRIPTION
The console unit tests were failing for the `set_pos` command when called with invalid arguments. The `MockSerial` class was not configured to return the expected error messages for these cases.

This commit adds the necessary mock responses to `robot_client.py` to simulate the error output for invalid servo IDs and positions, allowing the unit tests to pass.