### PR TITLE
test: Fix mock response order for export-states

### DIFF
--- a/tests/robot_client.py
+++ b/tests/robot_client.py
@@ -186,6 +186,8 @@ class MockSerial:
             self._in_buffer += b"Goal set.\nrobot>"
         elif b"save" in data:
             self._in_buffer += b"Saving network to NVS...\nrobot>"
+        elif b"export-states" in data:
+            self._in_buffer += b"--- BEGIN STATE EXPORT ---\n--- END STATE EXPORT ---\nrobot>"
         elif b"export" in data:
             self._in_buffer += b"{\"hidden_layer\":{...}}\nrobot>"
         elif b"reset_nn" in data:


### PR DESCRIPTION
The console unit test for the `export-states` command was failing because the mock response for the `export` command was being incorrectly triggered due to substring matching.

This commit reorders the `elif` blocks in the `MockSerial` class to check for the more specific "export-states" command before the "export" command, ensuring the correct mock response is returned.

The temporary debug logging has also been removed.